### PR TITLE
Updating protobuff version 7.34.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ numpy
 audio_recorder_streamlit
 streamlit==1.38.0
 torchaudio
-protobuf==3.20.*
+protobuf>=7.34.0


### PR DESCRIPTION
according to CVE-2026-0994 protobuff can be
exploited by denial of service where max recursion depth limit can be bypassed when parsing nested

commit-by: Chad